### PR TITLE
fix: stringstream concatenation

### DIFF
--- a/output.cpp
+++ b/output.cpp
@@ -184,11 +184,11 @@ string getMutTreeGraphViz(vector<string> label, int nodeCount, int m, int* paren
 	stringstream str;
 
 	str << "digraph g{\n";
-	str << nodes;
+	str << nodes.str();
 	str << "node [color=deeppink4, style=filled, fontcolor=white];	\n";
-	str << edges;
+	str << edges.str();
 	str << "node [color=lightgrey, style=filled, fontcolor=black];  \n";
-	str << leafedges;
+	str << leafedges.str();
 	str << "}\n";
 	return str.str();
 }


### PR DESCRIPTION
When trying to compile on Linux (Lubuntu 16.04 with g++ 5.4.0) with the following command:

```
g++ -std=c++11 *.cpp -o scite
```

the following error occurred:

```
output.cpp:187:9: error: cannot bind ‘std::ostream {aka std::basic_ostream<char>}’ lvalue to ‘std::basic_ostream<char>&&’
[...]
```

Traced it down to the concatenation of `stringstream`s which only worked when converting the right hand stringstream to string using `str()`.
